### PR TITLE
Switched to https

### DIFF
--- a/js/calendar_script.js
+++ b/js/calendar_script.js
@@ -60,7 +60,7 @@ function listUpcomingEvents() {
   request.execute(function(resp) {
     var events = resp.items;
     if (events.length > 0) {
-      $("ul").html("");
+      $("#calendar ul").html("");
       for (i = 0; i < events.length; i++) {
         var event = events[i];
         var when = event.start.dateTime;
@@ -73,7 +73,7 @@ function listUpcomingEvents() {
           minute = "0" + minute;
         }
         when = when.getDate() + '/' + when.getMonth() + " " + when.getHours() + ":" + minute;
-        $("#calender ul").append('<li>'+ event.summary + ' (' + when + ')' + '</li>');
+        $("#calendar ul").append('<li>'+ event.summary + ' (' + when + ')' + '</li>');
         console.log(event);
       }
     } else {

--- a/js/weather_script.js
+++ b/js/weather_script.js
@@ -1,25 +1,31 @@
-var icons = new Skycons({"color": "white"});
-function getweather() {
-    $.ajax({
-      url: "http://ip-api.com/json/?callback=?",
+var icons = new Skycons({
+  "color": "white"
+});
+
+function contactApi(lat, lon) {
+  console.log(lat)
+  console.log(lon)
+  $.ajax({
+      url: "https://api.forecast.io/forecast/70a79cc9ef81d5d038f26f0163b83d22/" + lat + "," + lon + "?callback=?",
       type: "GET",
       dataType: "json",
     })
-    .done(function(ip){
-      console.log(ip.lat)
-        console.log(ip.lon)
-        $.ajax({
-          url:"https://api.forecast.io/forecast/70a79cc9ef81d5d038f26f0163b83d22/" + ip.lat + "," + ip.lon + "?callback=?",
-          type: "GET",
-          dataType: "json",
-        })
-      .done(function(weather){
-        console.log(weather)
-        icons.set("weather", weather.currently.icon);
-        var t = weather.currently.temperature;
-        t = (t - 32) * 5 / 9.0;
-        t = Math.round( t * 100 ) / 100;
-        $("#temp").html(t + "°" );
-      })
+    .done(function(weather) {
+      console.log(weather)
+      icons.set("weather", weather.currently.icon);
+      var t = weather.currently.temperature;
+      t = (t - 32) * 5 / 9.0;
+      t = Math.round(t * 100) / 100;
+      $("#temp").html(t + "°");
     })
+}
+
+function getweather() {
+  if (navigator.geolocation) {
+    navigator.geolocation.getCurrentPosition(function(pos) {
+      contactApi(pos.coords.latitude, pos.coords.longitude)
+    })
+  } else {
+    contactApi(26.5130072, 80.2337094)
+  }
 }

--- a/js/weather_script.js
+++ b/js/weather_script.js
@@ -21,9 +21,14 @@ function contactApi(lat, lon) {
 }
 
 function getweather() {
+  console.log("Get Weather Called")
   if (navigator.geolocation) {
     navigator.geolocation.getCurrentPosition(function(pos) {
-      contactApi(pos.coords.latitude, pos.coords.longitude)
+      if (pos == null) {
+        contactApi(26.5130072, 80.2337094)
+      } else {
+        contactApi(pos.coords.latitude, pos.coords.longitude)
+      }
     })
   } else {
     contactApi(26.5130072, 80.2337094)


### PR DESCRIPTION
WebRTC requires a secure https connection (Atleast on chrome).
All modern browsers support location sharing, so we can use
html5 geolocation apis for better location. The ip api we were
using was not https, so it had to be removed.
